### PR TITLE
Fixes builds on fedora

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
-
+cmake-build-*
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,15 @@ add_executable(ddm ${DDM_SRCS})
 
 find_package(Threads REQUIRED)
 target_link_libraries(ddm ${CMAKE_THREAD_LIBS_INIT})
+
+find_path(CRYPTOPP_INCLUDE_DIR NAMES cryptopp/sha.h crypto++/sha.h)
+if(EXISTS ${CRYPTOPP_INCLUDE_DIR}/cryptopp/sha.h)
+    add_definitions(-DCRYPTOPP_NAMING)
+endif()
+
 find_library(CRYPTOPP cryptopp)
 target_link_libraries(ddm ${CRYPTOPP})
+
 set(BOOST_LIBS program_options)
 find_package(Boost COMPONENTS ${BOOST_LIBS} REQUIRED)
 target_link_libraries(ddm ${Boost_LIBRARIES})

--- a/core.cpp
+++ b/core.cpp
@@ -19,10 +19,7 @@
 #include <cassert>
 #include <iomanip>
 #include <unordered_set>
-#include <crypto++/sha.h>
-#include <crypto++/hex.h>
-#include <crypto++/files.h>
-#include <crypto++/filters.h>
+#include "cryptopp.h"
 #include "extfs.h"
 #include "core.h"
 

--- a/cryptopp.h
+++ b/cryptopp.h
@@ -1,0 +1,30 @@
+/***************************************************************************
+ *   Copyright (C) 2023 by Radu Andries                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ ***************************************************************************/
+
+#pragma once
+
+#ifdef CRYPTOPP_NAMING
+    #include <cryptopp/sha.h>
+    #include <cryptopp/hex.h>
+    #include <cryptopp/files.h>
+    #include <cryptopp/filters.h>
+#else
+    #include <crypto++/sha.h>
+    #include <crypto++/hex.h>
+    #include <crypto++/files.h>
+    #include <crypto++/filters.h>
+#endif // CRYPTOPP_NAMING


### PR DESCRIPTION
Build on fedora fails with:
```
admiral0@bragi ~/.s/d/build (master)> make
[ 20%] Building CXX object CMakeFiles/ddm.dir/core.cpp.o
/home/admiral0/.sources/directorydiffmerge/core.cpp:22:10: fatal error: crypto++/sha.h: No such file or directory
   22 | #include <crypto++/sha.h>
      |          ^~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/ddm.dir/build.make:104: CMakeFiles/ddm.dir/core.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/ddm.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
admiral0@bragi ~/.s/d/build (master) [2]> ls /usr/include/cryptopp/sha.h 
/usr/include/cryptopp/sha.h
```